### PR TITLE
Implement per-user assignment visibility

### DIFF
--- a/app/admin/assignment-requests/actions.tsx
+++ b/app/admin/assignment-requests/actions.tsx
@@ -7,16 +7,16 @@ export async function approve(formData: FormData) {
   const id = formData.get("id") as string;
   const genreId = formData.get("genreId") as string;
 
-  await prisma.$transaction([
-    prisma.assignmentRequest.update({
-      where: { id },
-      data: { status: "APPROVED", actedAt: new Date() },
-    }),
-    prisma.assignment.updateMany({
-      where: { genreId },
-      data: { isPublic: true },
-    }),
-  ]);
+  const request = await prisma.assignmentRequest.update({
+    where: { id },
+    data: { status: "APPROVED", actedAt: new Date() },
+  });
+
+  await prisma.genreAccess.upsert({
+    where: { userId_genreId: { userId: request.userId, genreId } },
+    create: { userId: request.userId, genreId },
+    update: {},
+  });
 
   revalidatePath("/admin/assignment-requests");
 }

--- a/app/admin/assignment-requests/page.tsx
+++ b/app/admin/assignment-requests/page.tsx
@@ -1,7 +1,6 @@
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
-import { revalidatePath } from "next/cache";
 
 import { approve, reject } from "./actions";
 

--- a/app/api/genre-requests/route.ts
+++ b/app/api/genre-requests/route.ts
@@ -10,8 +10,8 @@ export async function GET() {
   const genres = await prisma.genre.findMany({
     orderBy: { order: "asc" },
     include: {
-      assignments: { where: { isPublic: true }, select: { id: true } },
       _count: { select: { assignments: { where: { isPublic: true } } } },
+      GenreAccess: { where: { userId: session.user.id } },
       AssignmentRequest: {
         where: { userId: session.user.id },
         orderBy: { createdAt: "desc" },
@@ -23,7 +23,7 @@ export async function GET() {
   const result = genres.map((g) => ({
     id: g.id,
     name: g.name,
-    isOpen: g._count.assignments > 0,
+    isOpen: g._count.assignments > 0 || g.GenreAccess.length > 0,
     request: g.AssignmentRequest[0] ?? null, // {status:"PENDING"…} or null
   }));
 

--- a/app/assignments/[id]/page.tsx
+++ b/app/assignments/[id]/page.tsx
@@ -18,10 +18,16 @@ export default async function ViewAssignmentPage({ params }: Props) {
   if (!session?.user?.id) redirect("/api/auth/signin");
 
   const assignment = await prisma.assignment.findFirst({
-    where: { id: (await params).id },
+    where: {
+      id: (await params).id,
+      OR: [
+        { isPublic: true },
+        { genre: { GenreAccess: { some: { userId: session.user.id } } } },
+      ],
+    },
     include: { genre: true },
   });
-  if (!assignment) redirect("/admin/assignments");
+  if (!assignment) redirect("/");
 
   const progress = await prisma.assignmentProgress.findUnique({
     where: {

--- a/app/assignments/[id]/page.tsx
+++ b/app/assignments/[id]/page.tsx
@@ -20,10 +20,8 @@ export default async function ViewAssignmentPage({ params }: Props) {
   const assignment = await prisma.assignment.findFirst({
     where: {
       id: (await params).id,
-      OR: [
-        { isPublic: true },
-        { genre: { GenreAccess: { some: { userId: session.user.id } } } },
-      ],
+      isPublic: true,
+      genre: { GenreAccess: { some: { userId: session.user.id } } },
     },
     include: { genre: true },
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,12 @@ export default async function HomePage() {
 
   // ログイン済みなら公開課題一覧を表示
   const list = await prisma.assignment.findMany({
-    where: { isPublic: true },
+    where: {
+      OR: [
+        { isPublic: true },
+        { genre: { GenreAccess: { some: { userId: session.user.id } } } },
+      ],
+    },
     include: { genre: true },
     orderBy: [{ genre: { order: "asc" } }, { createdAt: "asc" }],
   });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -28,10 +28,8 @@ export default async function HomePage() {
   // ログイン済みなら公開課題一覧を表示
   const list = await prisma.assignment.findMany({
     where: {
-      OR: [
-        { isPublic: true },
-        { genre: { GenreAccess: { some: { userId: session.user.id } } } },
-      ],
+      isPublic: true,
+      genre: { GenreAccess: { some: { userId: session.user.id } } },
     },
     include: { genre: true },
     orderBy: [{ genre: { order: "asc" } }, { createdAt: "asc" }],

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -8,9 +8,9 @@ export default function ScrollRestorer() {
 
     const store = new Map<string, number>(); // pathname+search → scrollY
 
-    // tslint:disable-next-line:@typescript-eslint/no-explicit-any
-    // todo: 適切な型をつける
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onNavigate = (event: any) => {
+      // TODO: 型定義が存在しないため any を利用
       const fromKey = location.pathname + location.search;
       store.set(fromKey, window.scrollY);
 

--- a/prisma/migrations/20250531120000_add_genre_access/migration.sql
+++ b/prisma/migrations/20250531120000_add_genre_access/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "GenreAccess" (
+    "userId" TEXT NOT NULL,
+    "genreId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "GenreAccess_pkey" PRIMARY KEY ("userId", "genreId")
+);
+
+-- AddForeignKey
+ALTER TABLE "GenreAccess" ADD CONSTRAINT "GenreAccess_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "GenreAccess" ADD CONSTRAINT "GenreAccess_genreId_fkey" FOREIGN KEY ("genreId") REFERENCES "Genre"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20250604121000_seed_database_access/migration.sql
+++ b/prisma/migrations/20250604121000_seed_database_access/migration.sql
@@ -1,0 +1,7 @@
+-- Seed default genre access for all users
+INSERT INTO "GenreAccess" ("userId", "genreId")
+SELECT u."id", g."id"
+FROM "User" u
+CROSS JOIN "Genre" g
+WHERE g."name" = 'データベース'
+ON CONFLICT DO NOTHING;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,8 @@ model User {
   userRequest UserRequest[]
 
   AssignmentRequest AssignmentRequest[]
+
+  GenreAccess GenreAccess[]
 }
 
 model Assignment {
@@ -104,6 +106,17 @@ model AssignmentRequest {
   @@unique([userId, genreId, status], name: "user_genre_unique_pending")
 }
 
+model GenreAccess {
+  userId  String
+  genreId String
+  createdAt DateTime @default(now())
+
+  user  User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  genre Genre @relation(fields: [genreId], references: [id], onDelete: Cascade)
+
+  @@id([userId, genreId])
+}
+
 enum MembershipStatus {
   ACTIVE
   PAUSED
@@ -126,10 +139,12 @@ model Genre {
   id          String       @id @default(cuid())
   name        String       @unique
   description String?
-  order       Int          @default(0)   
+  order       Int          @default(0)
   assignments Assignment[]
 
   AssignmentRequest AssignmentRequest[]
+
+  GenreAccess GenreAccess[]
 }
 
 


### PR DESCRIPTION
## Summary
- allow genre access per user via new `GenreAccess` model
- approve requests by granting access instead of toggling global publish
- filter assignments by per-user access
- restrict direct assignment links to authorized users
- track user access state in `genre-requests` API
- fix lint warnings in ScrollRestorer provider

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684054a80eb88332a4f8b5d70b306d8f