### PR TITLE
Improve mobile menu overlay with fade effect

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -44,7 +44,9 @@ export function Header() {
         {/* ブランド */}
         <Link href="/" className="flex items-center hover:opacity-80">
           <Image src={Logo} alt="APA Logo" width={40} height={40} />
-          <span className="ml-2 font-bold text-xl">Agile Practice Assignment</span>
+          <span className="ml-2 font-bold text-xl">
+            Agile Practice Assignment
+          </span>
         </Link>
 
         {/* PC: メニュー＋サインインアウト, SP: ハンバーガー */}
@@ -110,18 +112,32 @@ export function Header() {
 
       {/* スマホメニュー */}
       <div
-        className={`md:hidden fixed inset-0 bg-black/75 z-40 flex flex-col p-4 gap-4 transition-opacity duration-300 ${open ? "opacity-100" : "opacity-0 pointer-events-none"}`}
+        className={`md:hidden fixed inset-0 bg-black/85 z-40  flex flex-col items-center p-6 gap-4 transition-opacity duration-300 ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
       >
-        <nav className="flex flex-col gap-4 text-white mt-12">
+        <nav className="flex flex-col gap-6 text-white mt-12 text-2xl">
           {inAdmin && (
             <>
-              <Link href="/admin/assignments" className="hover:underline hover:text-gray-300">
+              <Link
+                href="/admin/assignments"
+                className="hover:underline hover:text-gray-300"
+                onClick={() => setOpen(false)}
+              >
                 課題編集
               </Link>
-              <Link href="/admin/progress" className="hover:underline hover:text-gray-300">
+              <Link
+                href="/admin/progress"
+                className="hover:underline hover:text-gray-300"
+                onClick={() => setOpen(false)}
+              >
                 進捗一覧
               </Link>
-              <Link href="/admin/requests" className="relative">
+              <Link
+                href="/admin/requests"
+                className="relative"
+                onClick={() => setOpen(false)}
+              >
                 休会・退会リクエスト
                 {pendingRequestCount > 0 && (
                   <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
@@ -132,7 +148,11 @@ export function Header() {
             </>
           )}
           {session && !inAdmin && (
-            <Link href="/settings" className="hover:underline hover:text-gray-300">
+            <Link
+              href="/settings"
+              className="hover:underline hover:text-gray-300"
+              onClick={() => setOpen(false)}
+            >
               設定
             </Link>
           )}
@@ -143,6 +163,7 @@ export function Header() {
               <Link
                 href="/signin"
                 className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition block text-center"
+                onClick={() => setOpen(false)}
               >
                 サインイン
               </Link>
@@ -151,7 +172,7 @@ export function Header() {
         </nav>
         <button
           onClick={() => setOpen(false)}
-          className="mt-auto px-4 py-2 rounded border border-white text-white hover:bg-white/20 transition"
+          className="mt-auto px-4 py-2 rounded border border-white text-white hover:bg-white/20 transition w-full"
         >
           閉じる
         </button>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -77,12 +77,17 @@ export function Header() {
               </>
             )}
             {session && !inAdmin && (
-              <Link
-                href="/settings"
-                className="hover:underline hover:text-gray-300"
-              >
-                設定
-              </Link>
+              <div className="space-x-6">
+                <Link href="/" className="hover:underline hover:text-gray-300">
+                  課題一覧
+                </Link>
+                <Link
+                  href="/settings"
+                  className="hover:underline hover:text-gray-300"
+                >
+                  設定
+                </Link>
+              </div>
             )}
           </nav>
 
@@ -116,7 +121,7 @@ export function Header() {
           open ? "opacity-100" : "opacity-0 pointer-events-none"
         }`}
       >
-        <nav className="flex flex-col gap-6 text-white mt-12 text-2xl">
+        <nav className="flex flex-col gap-6 items-center text-white mt-12 text-2xl">
           {inAdmin && (
             <>
               <Link
@@ -148,13 +153,22 @@ export function Header() {
             </>
           )}
           {session && !inAdmin && (
-            <Link
-              href="/settings"
-              className="hover:underline hover:text-gray-300"
-              onClick={() => setOpen(false)}
-            >
-              設定
-            </Link>
+            <>
+              <Link
+                href="/"
+                className="hover:underline hover:text-gray-300"
+                onClick={() => setOpen(false)}
+              >
+                課題一覧
+              </Link>
+              <Link
+                href="/settings"
+                className="hover:underline hover:text-gray-300"
+                onClick={() => setOpen(false)}
+              >
+                設定
+              </Link>
+            </>
           )}
           <div>
             {session ? (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -149,6 +149,12 @@ export function Header() {
             )}
           </div>
         </nav>
+        <button
+          onClick={() => setOpen(false)}
+          className="mt-auto px-4 py-2 rounded border border-white text-white hover:bg-white/20 transition"
+        >
+          閉じる
+        </button>
       </div>
     </header>
   );

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -109,54 +109,47 @@ export function Header() {
       </div>
 
       {/* スマホメニュー */}
-      <nav
-        className={`md:hidden mt-2 flex flex-col gap-2 ${open ? "" : "hidden"}`}
+      <div
+        className={`md:hidden fixed inset-0 bg-black/75 z-40 flex flex-col p-4 gap-4 transition-opacity duration-300 ${open ? "opacity-100" : "opacity-0 pointer-events-none"}`}
       >
-        {inAdmin && (
-          <>
-            <Link
-              href="/admin/assignments"
-              className="hover:underline hover:text-gray-300"
-            >
-              課題編集
-            </Link>
-            <Link
-              href="/admin/progress"
-              className="hover:underline hover:text-gray-300"
-            >
-              進捗一覧
-            </Link>
-            <Link href="/admin/requests" className="relative">
-              休会・退会リクエスト
-              {pendingRequestCount > 0 && (
-                <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
-                  {pendingRequestCount}
-                </span>
-              )}
-            </Link>
-          </>
-        )}
-        {session && !inAdmin && (
-          <Link
-            href="/settings"
-            className="hover:underline hover:text-gray-300"
-          >
-            設定
-          </Link>
-        )}
-        <div>
-          {session ? (
-            <SignOutButton />
-          ) : (
-            <Link
-              href="/signin"
-              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition block text-center"
-            >
-              サインイン
+        <nav className="flex flex-col gap-4 text-white mt-12">
+          {inAdmin && (
+            <>
+              <Link href="/admin/assignments" className="hover:underline hover:text-gray-300">
+                課題編集
+              </Link>
+              <Link href="/admin/progress" className="hover:underline hover:text-gray-300">
+                進捗一覧
+              </Link>
+              <Link href="/admin/requests" className="relative">
+                休会・退会リクエスト
+                {pendingRequestCount > 0 && (
+                  <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
+                    {pendingRequestCount}
+                  </span>
+                )}
+              </Link>
+            </>
+          )}
+          {session && !inAdmin && (
+            <Link href="/settings" className="hover:underline hover:text-gray-300">
+              設定
             </Link>
           )}
-        </div>
-      </nav>
+          <div>
+            {session ? (
+              <SignOutButton />
+            ) : (
+              <Link
+                href="/signin"
+                className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition block text-center"
+              >
+                サインイン
+              </Link>
+            )}
+          </div>
+        </nav>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- overlay the mobile menu over the page
- add fade transition on menu open/close

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pnpm install` *(fails: 403 retrieving prisma engine)*

------
https://chatgpt.com/codex/tasks/task_e_684420db9e048332949471ba09c20f62