### PR TITLE
Add badge for assignment requests

### DIFF
--- a/app/admin/assignment-requests/components/Row.tsx
+++ b/app/admin/assignment-requests/components/Row.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { approve, reject } from "../actions";
+import type { AssignmentRequest, User, Genre } from "@prisma/client";
+import { useTransition } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+export type FullAssignmentRequest = AssignmentRequest & {
+  user: Pick<User, "name" | "email">;
+  genre: Pick<Genre, "name">;
+};
+
+export default function Row({ r }: { r: FullAssignmentRequest }) {
+  const qc = useQueryClient();
+  const [isPending, startTransition] = useTransition();
+
+  const onSubmit =
+    (action: (fd: FormData) => Promise<void>) => (fd: FormData) => {
+      startTransition(async () => {
+        await action(fd);
+        qc.invalidateQueries({ queryKey: ["assignment-pending-count"] });
+      });
+    };
+
+  return (
+    <tr className="border-b" key={r.id}>
+      <td className="border px-3 py-2">{r.user.name ?? r.user.email}</td>
+      <td className="border px-3 py-2">{r.genre.name}</td>
+      <td className="border px-3 py-2">{r.createdAt.toLocaleString()}</td>
+      <td className="border px-3 py-2">
+        {isPending ? "処理中...." : r.status === "PENDING" ? (
+          <span className="text-yellow-600">未処理</span>
+        ) : r.status === "APPROVED" ? (
+          <span className="text-green-600">承認済み</span>
+        ) : (
+          <span className="text-gray-500">却下</span>
+        )}
+      </td>
+      <td className="border px-3 py-2 w-32">
+        {r.status === "PENDING" && (
+          <div className="flex gap-1 justify-center">
+            <form action={onSubmit(approve)}>
+              <input type="hidden" name="id" value={r.id} />
+              <input type="hidden" name="genreId" value={r.genreId} />
+              <button className="px-2 py-1 bg-green-500 text-white rounded text-xs">
+                承認
+              </button>
+            </form>
+            <form action={onSubmit(reject)}>
+              <input type="hidden" name="id" value={r.id} />
+              <button className="px-2 py-1 bg-gray-400 text-white rounded text-xs">
+                却下
+              </button>
+            </form>
+          </div>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/app/admin/assignment-requests/page.tsx
+++ b/app/admin/assignment-requests/page.tsx
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma";
 import { redirect } from "next/navigation";
 
 import { approve, reject } from "./actions";
+import Row, { FullAssignmentRequest } from "./components/Row";
 
 export default async function AdminAssignmentRequestsPage() {
   /* 認証チェック（簡易） */
@@ -15,7 +16,7 @@ export default async function AdminAssignmentRequestsPage() {
     orderBy: { createdAt: "asc" },
     include: {
       user: { select: { name: true, email: true } },
-      genre: true,
+      genre: { select: { name: true } },
     },
   });
 
@@ -36,53 +37,7 @@ export default async function AdminAssignmentRequestsPage() {
 
         <tbody>
           {requests.map((r) => (
-            <tr key={r.id} className="border-b">
-              {/* 受講生 */}
-              <td className="border px-3 py-2">
-                {r.user.name ?? r.user.email}
-              </td>
-
-              {/* ジャンル */}
-              <td className="border px-3 py-2">{r.genre.name}</td>
-
-              {/* 申請日時 */}
-              <td className="border px-3 py-2">
-                {r.createdAt.toLocaleString()}
-              </td>
-
-              {/* ステータス */}
-              <td className="border px-3 py-2">
-                {
-                  {
-                    PENDING: <span className="text-yellow-600">未処理</span>,
-                    APPROVED: <span className="text-green-600">承認済み</span>,
-                    REJECTED: <span className="text-gray-500">却下</span>,
-                  }[r.status]
-                }
-              </td>
-
-              {/* 操作ボタン */}
-              <td className="border px-3 py-2">
-                {r.status === "PENDING" && (
-                  <div className="flex gap-1 justify-center">
-                    <form action={approve}>
-                      <input type="hidden" name="id" value={r.id} />
-                      <input type="hidden" name="genreId" value={r.genreId} />
-                      <button className="px-2 py-1 bg-green-500 text-white rounded text-xs">
-                        承認
-                      </button>
-                    </form>
-
-                    <form action={reject}>
-                      <input type="hidden" name="id" value={r.id} />
-                      <button className="px-2 py-1 bg-gray-400 text-white rounded text-xs">
-                        却下
-                      </button>
-                    </form>
-                  </div>
-                )}
-              </td>
-            </tr>
+            <Row key={r.id} r={r as FullAssignmentRequest} />
           ))}
         </tbody>
       </table>

--- a/app/api/assignment-requests/pending-count/route.ts
+++ b/app/api/assignment-requests/pending-count/route.ts
@@ -1,0 +1,7 @@
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const count = await prisma.assignmentRequest.count({ where: { status: "PENDING" } });
+  return NextResponse.json({ count }, { headers: { "cache-control": "no-store" } });
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -14,6 +14,11 @@ const fetchCount = async () =>
     count: number;
   }>;
 
+const fetchAssignmentCount = async () =>
+  (await fetch("/api/assignment-requests/pending-count")).json() as Promise<{
+    count: number;
+  }>;
+
 export function Header() {
   const { data: session, status } = useSession();
   const pathname = usePathname(); // ★ 現在のパスを取得
@@ -28,7 +33,15 @@ export function Header() {
     staleTime: 30_000, // 30 秒キャッシュ
   });
 
+  const { data: assignmentData } = useQuery({
+    queryKey: ["assignment-pending-count"],
+    queryFn: fetchAssignmentCount,
+    enabled: inAdmin,
+    staleTime: 30_000,
+  });
+
   const pendingRequestCount = data?.count ?? 0;
+  const pendingAssignmentRequestCount = assignmentData?.count ?? 0;
 
   if (status === "loading") {
     return (
@@ -71,6 +84,14 @@ export function Header() {
                   {pendingRequestCount > 0 && (
                     <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
                       {pendingRequestCount}
+                    </span>
+                  )}
+                </Link>
+                <Link href="/admin/assignment-requests" className="relative">
+                  課題公開リクエスト
+                  {pendingAssignmentRequestCount > 0 && (
+                    <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
+                      {pendingAssignmentRequestCount}
                     </span>
                   )}
                 </Link>
@@ -147,6 +168,18 @@ export function Header() {
                 {pendingRequestCount > 0 && (
                   <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
                     {pendingRequestCount}
+                  </span>
+                )}
+              </Link>
+              <Link
+                href="/admin/assignment-requests"
+                className="relative"
+                onClick={() => setOpen(false)}
+              >
+                課題公開リクエスト
+                {pendingAssignmentRequestCount > 0 && (
+                  <span className="absolute -top-2 -right-4 bg-red-500 text-white text-xs rounded-full px-2">
+                    {pendingAssignmentRequestCount}
                   </span>
                 )}
               </Link>


### PR DESCRIPTION
## Summary
- show a count badge for pending assignment requests like other requests
- fetch assignment request pending count via new API
- invalidate query when approving/rejecting assignments

## Testing
- `pnpm install` *(fails: Failed to fetch prisma engines)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442dca829c833281ce6ae953165602