### PR TITLE
ジャンル別進捗表

### DIFF
--- a/app/admin/progress/page.tsx
+++ b/app/admin/progress/page.tsx
@@ -9,9 +9,15 @@ export default async function AdminProgressPage() {
 
   /* 課題一覧 */
   const assignments = await prisma.assignment.findMany({
-    select: { id: true, title: true },
-    orderBy: { title: "asc" },
+    include: { genre: true },
+    orderBy: [{ genre: { order: "asc" } }, { title: "asc" }],
   });
+
+  const formattedAssignments = assignments.map((a) => ({
+    id: a.id,
+    title: a.title,
+    genre: a.genre?.name ?? "未分類",
+  }));
 
   /* 全ユーザー＋進捗 */
   const users = await prisma.user.findMany({
@@ -29,7 +35,7 @@ export default async function AdminProgressPage() {
   return (
     <div className="p-6">
       <h1 className="text-2xl font-bold mb-4">受講生 × 課題 進捗一覧</h1>
-      <AdminProgressTable assignments={assignments} users={users} />
+      <AdminProgressTable assignments={formattedAssignments} users={users} />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import PublicAssignments from "@/components/PublicAssignments";
-import { ProgressStatus } from "@/lib/constants";
 
 export default async function HomePage() {
   const session = await auth();

--- a/components/AdminProgressTable.tsx
+++ b/components/AdminProgressTable.tsx
@@ -2,10 +2,10 @@
 
 import {
   STATUS_INFO,
-  ProgressStatus,
   GENRE_STYLE,
   DEFAULT_STYLE,
 } from "@/lib/constants";
+import type { ProgressStatus } from "@/lib/constants";
 
 type Assignment = { id: string; title: string; genre: string };
 type Progress = { assignmentId: string; status: ProgressStatus };
@@ -29,12 +29,16 @@ export default function AdminProgressTable({
   }, {});
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {Object.entries(grouped).map(([genre, list]) => {
         const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;
         return (
-          <div key={genre} className="overflow-auto">
-            <h2 className={`font-semibold mb-2 ${style.text}`}>{genre}</h2>
+          <details key={genre} className="overflow-auto border rounded">
+            <summary
+              className={`px-2 py-1 mb-2 cursor-pointer select-none font-semibold ${style.text}`}
+            >
+              {genre}
+            </summary>
             <table className="min-w-full border border-gray-300 text-sm">
               <thead className="bg-gray-100 sticky top-0">
                 <tr>
@@ -76,7 +80,7 @@ export default function AdminProgressTable({
                 })}
               </tbody>
             </table>
-          </div>
+          </details>
         );
       })}
     </div>

--- a/components/AdminProgressTable.tsx
+++ b/components/AdminProgressTable.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { STATUS_INFO, ProgressStatus } from "@/lib/constants";
+import {
+  STATUS_INFO,
+  ProgressStatus,
+  GENRE_STYLE,
+  DEFAULT_STYLE,
+} from "@/lib/constants";
 
-type Assignment = { id: string; title: string };
+type Assignment = { id: string; title: string; genre: string };
 type Progress = { assignmentId: string; status: ProgressStatus };
 type User = {
   id: string;
@@ -18,49 +23,62 @@ export default function AdminProgressTable({
   assignments: Assignment[];
   users: User[];
 }) {
+  const grouped = assignments.reduce<Record<string, Assignment[]>>((acc, a) => {
+    (acc[a.genre] ||= []).push(a);
+    return acc;
+  }, {});
+
   return (
-    <div className="overflow-auto">
-      <table className="min-w-full border border-gray-300 text-sm">
-        <thead className="bg-gray-100 sticky top-0">
-          <tr>
-            <th className="border px-3 py-2 whitespace-nowrap text-left">
-              受講生
-            </th>
-            {assignments.map((a) => (
-              <th key={a.id} className="border px-3 py-2 whitespace-nowrap">
-                {a.title}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {users.map((u) => {
-            const map = Object.fromEntries(
-              u.assignmentProgress.map((p) => [p.assignmentId, p.status])
-            );
-            return (
-              <tr key={u.id}>
-                <td className="border px-3 py-2 whitespace-nowrap font-medium">
-                  {u.name ?? u.email}
-                </td>
-                {assignments.map((a) => {
-                  const st = map[a.id] ?? "NOT_STARTED";
-                  const { label, bg, text } = STATUS_INFO[st];
+    <div className="space-y-8">
+      {Object.entries(grouped).map(([genre, list]) => {
+        const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;
+        return (
+          <div key={genre} className="overflow-auto">
+            <h2 className={`font-semibold mb-2 ${style.text}`}>{genre}</h2>
+            <table className="min-w-full border border-gray-300 text-sm">
+              <thead className="bg-gray-100 sticky top-0">
+                <tr>
+                  <th className="border px-3 py-2 whitespace-nowrap text-left">
+                    受講生
+                  </th>
+                  {list.map((a) => (
+                    <th key={a.id} className="border px-3 py-2 whitespace-nowrap">
+                      {a.title}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => {
+                  const map = Object.fromEntries(
+                    u.assignmentProgress.map((p) => [p.assignmentId, p.status])
+                  );
                   return (
-                    <td key={a.id} className="border px-3 py-2 text-center">
-                      <span
-                        className={`inline-block px-2 py-0.5 rounded ${bg} ${text}`}
-                      >
-                        {label}
-                      </span>
-                    </td>
+                    <tr key={u.id}>
+                      <td className="border px-3 py-2 whitespace-nowrap font-medium">
+                        {u.name ?? u.email}
+                      </td>
+                      {list.map((a) => {
+                        const st = map[a.id] ?? "NOT_STARTED";
+                        const { label, bg, text } = STATUS_INFO[st];
+                        return (
+                          <td key={a.id} className="border px-3 py-2 text-center">
+                            <span
+                              className={`inline-block px-2 py-0.5 rounded ${bg} ${text}`}
+                            >
+                              {label}
+                            </span>
+                          </td>
+                        );
+                      })}
+                    </tr>
                   );
                 })}
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+              </tbody>
+            </table>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/components/AdminProgressTable.tsx
+++ b/components/AdminProgressTable.tsx
@@ -78,10 +78,16 @@ export default function AdminProgressTable({
 
   return (
     <div className="space-y-4">
-      <label className="flex items-center gap-2">
-        <span className="text-sm">ジャンル別表示</span>
-        <Switch checked={byGenre} onCheckedChange={setByGenre} />
-      </label>
+      <div className="flex items-center gap-2">
+        <span id="genre-toggle-label" className="text-sm">
+          ジャンル別表示
+        </span>
+        <Switch
+          aria-labelledby="genre-toggle-label"
+          checked={byGenre}
+          onCheckedChange={setByGenre}
+        />
+      </div>
       {byGenre ? (
         Object.entries(grouped).map(([genre, list]) => {
           const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;

--- a/components/AdminProgressTable.tsx
+++ b/components/AdminProgressTable.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useMemo, useState } from "react";
 import {
   STATUS_INFO,
   GENRE_STYLE,
   DEFAULT_STYLE,
+  type ProgressStatus,
 } from "@/lib/constants";
-import type { ProgressStatus } from "@/lib/constants";
+import { Switch } from "@/components/ui/switch";
 
 type Assignment = { id: string; title: string; genre: string };
 type Progress = { assignmentId: string; status: ProgressStatus };
@@ -23,80 +25,80 @@ export default function AdminProgressTable({
   assignments: Assignment[];
   users: User[];
 }) {
-  const grouped = assignments.reduce<Record<string, Assignment[]>>((acc, a) => {
-    (acc[a.genre] ||= []).push(a);
-    return acc;
-  }, {});
+  const [byGenre, setByGenre] = useState(false);
+
+  const grouped = useMemo(() => {
+    return assignments.reduce<Record<string, Assignment[]>>((acc, a) => {
+      (acc[a.genre] ||= []).push(a);
+      return acc;
+    }, {});
+  }, [assignments]);
+
+  const renderTable = (list: Assignment[]) => (
+    <table className="min-w-full border border-gray-300 text-sm">
+      <thead className="bg-gray-100 sticky top-0">
+        <tr>
+          <th className="border px-3 py-2 whitespace-nowrap text-left">受講生</th>
+          {list.map((a) => (
+            <th key={a.id} className="border px-3 py-2 whitespace-nowrap">
+              {a.title}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {users.map((u) => {
+          const map = Object.fromEntries(
+            u.assignmentProgress.map((p) => [p.assignmentId, p.status])
+          );
+          return (
+            <tr key={u.id}>
+              <td className="border px-3 py-2 whitespace-nowrap font-medium">
+                {u.name ?? u.email}
+              </td>
+              {list.map((a) => {
+                const st = map[a.id] ?? "NOT_STARTED";
+                const { label, bg, text } = STATUS_INFO[st];
+                return (
+                  <td key={a.id} className="border px-3 py-2 text-center">
+                    <span
+                      className={`inline-block px-2 py-0.5 rounded ${bg} ${text}`}
+                    >
+                      {label}
+                    </span>
+                  </td>
+                );
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
 
   return (
-    <div className="space-y-6">
-      {Object.entries(grouped).map(([genre, list]) => {
-        const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;
-        return (
-          <details key={genre} className="overflow-auto border rounded">
-            <summary
-              className={`px-2 py-1 mb-2 cursor-pointer select-none font-semibold ${style.text}`}
-            >
-              {genre}
-            </summary>
-            <table className="min-w-full border border-gray-300 text-sm">
-              <thead className="bg-gray-100 sticky top-0">
-                <tr>
-                  <th className="border px-3 py-2 whitespace-nowrap text-left">
-                    受講生
-                  </th>
-                  {list.map((a) => (
-                    <th key={a.id} className="border px-3 py-2 whitespace-nowrap">
-                      {a.title}
-                    </th>
-                  ))}
-                  <th className="border px-3 py-2 whitespace-nowrap text-center">
-                    完了/未着手
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {users.map((u) => {
-                  const map = Object.fromEntries(
-                    u.assignmentProgress.map((p) => [p.assignmentId, p.status])
-                  );
-                  const { done, notStarted } = u.assignmentProgress.reduce(
-                    (acc, p) => {
-                      if (p.status === "DONE") acc.done++;
-                      if (p.status === "NOT_STARTED") acc.notStarted++;
-                      return acc;
-                    },
-                    { done: 0, notStarted: 0 }
-                  );
-                  return (
-                    <tr key={u.id}>
-                      <td className="border px-3 py-2 whitespace-nowrap font-medium">
-                        {u.name ?? u.email}
-                      </td>
-                      {list.map((a) => {
-                        const st = map[a.id] ?? "NOT_STARTED";
-                        const { label, bg, text } = STATUS_INFO[st];
-                        return (
-                          <td key={a.id} className="border px-3 py-2 text-center">
-                            <span
-                              className={`inline-block px-2 py-0.5 rounded ${bg} ${text}`}
-                            >
-                              {label}
-                            </span>
-                          </td>
-                        );
-                      })}
-                      <td className="border px-3 py-2 whitespace-nowrap text-center">
-                        {done}/{notStarted}
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </details>
-        );
-      })}
+    <div className="space-y-4">
+      <label className="flex items-center gap-2">
+        <span className="text-sm">ジャンル別表示</span>
+        <Switch checked={byGenre} onCheckedChange={setByGenre} />
+      </label>
+      {byGenre ? (
+        Object.entries(grouped).map(([genre, list]) => {
+          const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;
+          return (
+            <details key={genre} className="overflow-auto border rounded">
+              <summary
+                className={`px-2 py-1 mb-2 cursor-pointer select-none font-semibold ${style.text}`}
+              >
+                {genre}
+              </summary>
+              {renderTable(list)}
+            </details>
+          );
+        })
+      ) : (
+        <div className="overflow-auto">{renderTable(assignments)}</div>
+      )}
     </div>
   );
 }

--- a/components/AdminProgressTable.tsx
+++ b/components/AdminProgressTable.tsx
@@ -38,7 +38,9 @@ export default function AdminProgressTable({
     <table className="min-w-full border border-gray-300 text-sm">
       <thead className="bg-gray-100 sticky top-0">
         <tr>
-          <th className="border px-3 py-2 whitespace-nowrap text-left">受講生</th>
+          <th className="border px-3 py-2 whitespace-nowrap text-left">
+            受講生
+          </th>
           {list.map((a) => (
             <th key={a.id} className="border px-3 py-2 whitespace-nowrap">
               {a.title}

--- a/components/AdminProgressTable.tsx
+++ b/components/AdminProgressTable.tsx
@@ -50,12 +50,23 @@ export default function AdminProgressTable({
                       {a.title}
                     </th>
                   ))}
+                  <th className="border px-3 py-2 whitespace-nowrap text-center">
+                    完了/未着手
+                  </th>
                 </tr>
               </thead>
               <tbody>
                 {users.map((u) => {
                   const map = Object.fromEntries(
                     u.assignmentProgress.map((p) => [p.assignmentId, p.status])
+                  );
+                  const { done, notStarted } = u.assignmentProgress.reduce(
+                    (acc, p) => {
+                      if (p.status === "DONE") acc.done++;
+                      if (p.status === "NOT_STARTED") acc.notStarted++;
+                      return acc;
+                    },
+                    { done: 0, notStarted: 0 }
                   );
                   return (
                     <tr key={u.id}>
@@ -75,6 +86,9 @@ export default function AdminProgressTable({
                           </td>
                         );
                       })}
+                      <td className="border px-3 py-2 whitespace-nowrap text-center">
+                        {done}/{notStarted}
+                      </td>
                     </tr>
                   );
                 })}


### PR DESCRIPTION
## Summary
- group progress table by genre using `GENRE_STYLE`
- include genre info when fetching assignments

## Testing
- `pnpm install --frozen-lockfile` *(fails: Failed to fetch the engine file)*
- `npm run lint` *(fails: 'ProgressStatus' is defined but never used)*

------
https://chatgpt.com/codex/tasks/task_e_684594be58e88332a255e713e962a085