### PR TITLE
Implement horizontal scroll restoration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
       <body className="h-dvh">
         <QueryProvider>
           <SessionProvider>
-            <Suspense fallback={null}>
+            <Suspense fallback={<>ScrollRestorer Fallback</>}>
               <ScrollRestorer />
             </Suspense>
             <Header />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Header } from "@/components/Header";
 import QueryProvider from "@/lib/providers/QueryClientProvider";
 import ScrollRestorer from "@/lib/providers/ScrollRestorer";
+import { Suspense } from "react";
 
 export default function RootLayout({
   children,
@@ -14,7 +15,9 @@ export default function RootLayout({
       <body className="h-dvh">
         <QueryProvider>
           <SessionProvider>
-            <ScrollRestorer />
+            <Suspense fallback={null}>
+              <ScrollRestorer />
+            </Suspense>
             <Header />
             {children}
           </SessionProvider>

--- a/components/PublicAssignments.tsx
+++ b/components/PublicAssignments.tsx
@@ -50,7 +50,10 @@ function GenreBlock({
         data-scroll-key={`list-${genre}`}
       >
         {list.map((a) => (
-          <ViewTransition key={`assignment-${a.id}`} name={`assignment-${a.id}`}>
+          <ViewTransition
+            key={`assignment-${a.id}`}
+            name={`assignment-${a.id}`}
+          >
             <Link
               href={`/assignments/${a.id}`}
               className={`relative w-72 shadow hover:shadow-md p-6 rounded-lg shrink-0 border-l-4  ${style.border}`}

--- a/components/PublicAssignments.tsx
+++ b/components/PublicAssignments.tsx
@@ -76,7 +76,10 @@ export default function PublicAssignments({ assignments }: Props) {
               </h2>
 
               {/* 横スクロールコンテナ */}
-              <div className="flex gap-4 overflow-x-auto scroll-smooth pb-2">
+              <div
+                className="flex gap-4 overflow-x-auto scroll-smooth pb-2"
+                data-scroll-key={`list-${genre}`}
+              >
                 {list.map((a) => (
                   <ViewTransition
                     key={`assignment-${a.id}`}

--- a/components/PublicAssignments.tsx
+++ b/components/PublicAssignments.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
-import { unstable_ViewTransition as ViewTransition } from "react";
+import { unstable_ViewTransition as ViewTransition, useRef } from "react";
+import useHorizontalScrollRestore from "@/lib/hooks/useHorizontalScrollRestore";
 import {
   GENRE_STYLE,
   DEFAULT_STYLE,
@@ -29,6 +30,48 @@ type GenreInfo = {
   canRequest: boolean;
   request: { status: "PENDING" } | null;
 };
+
+function GenreBlock({
+  genre,
+  list,
+}: {
+  genre: string;
+  list: PublicAssignment[];
+}) {
+  const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;
+  const ref = useRef<HTMLDivElement>(null);
+  useHorizontalScrollRestore(`list-${genre}`, ref);
+  return (
+    <div className="mb-12">
+      <h2 className={`text-2xl font-semibold mb-4 ${style.text}`}>{genre}</h2>
+      <div
+        ref={ref}
+        className="flex gap-4 overflow-x-auto scroll-smooth pb-2"
+        data-scroll-key={`list-${genre}`}
+      >
+        {list.map((a) => (
+          <ViewTransition key={`assignment-${a.id}`} name={`assignment-${a.id}`}>
+            <Link
+              href={`/assignments/${a.id}`}
+              className={`relative w-72 shadow hover:shadow-md p-6 rounded-lg shrink-0 border-l-4  ${style.border}`}
+            >
+              <span
+                className={`absolute top-1 right-1 flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded ${
+                  STATUS_INFO[a.status].bg
+                } ${STATUS_INFO[a.status].text}`}
+              >
+                {a.status === "DONE" && <CheckCircle className="w-4 h-4" />}
+                {STATUS_INFO[a.status].label}
+              </span>
+              <h3 className="text-xl font-medium mb-2 truncate">{a.title}</h3>
+              <p className="text-gray-700 text-sm line-clamp-3">{a.excerpt}</p>
+            </Link>
+          </ViewTransition>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 export default function PublicAssignments({ assignments }: Props) {
   const qc = useQueryClient();
@@ -67,51 +110,9 @@ export default function PublicAssignments({ assignments }: Props) {
         </p>
       ) : (
         /* ---------- 各ジャンル ---------- */
-        Object.entries(grouped).map(([genre, list]) => {
-          const style = GENRE_STYLE[genre] ?? DEFAULT_STYLE;
-          return (
-            <div key={genre} className="mb-12">
-              <h2 className={`text-2xl font-semibold mb-4 ${style.text}`}>
-                {genre}
-              </h2>
-
-              {/* 横スクロールコンテナ */}
-              <div
-                className="flex gap-4 overflow-x-auto scroll-smooth pb-2"
-                data-scroll-key={`list-${genre}`}
-              >
-                {list.map((a) => (
-                  <ViewTransition
-                    key={`assignment-${a.id}`}
-                    name={`assignment-${a.id}`}
-                  >
-                    <Link
-                      href={`/assignments/${a.id}`}
-                      className={`relative w-72 shadow hover:shadow-md p-6 rounded-lg shrink-0 border-l-4  ${style.border}`}
-                    >
-                      <span
-                        className={`absolute top-1 right-1 flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded ${
-                          STATUS_INFO[a.status].bg
-                        } ${STATUS_INFO[a.status].text}`}
-                      >
-                        {a.status === "DONE" && (
-                          <CheckCircle className="w-4 h-4" />
-                        )}
-                        {STATUS_INFO[a.status].label}
-                      </span>
-                      <h3 className="text-xl font-medium mb-2 truncate">
-                        {a.title}
-                      </h3>
-                      <p className="text-gray-700 text-sm line-clamp-3">
-                        {a.excerpt}
-                      </p>
-                    </Link>
-                  </ViewTransition>
-                ))}
-              </div>
-            </div>
-          );
-        })
+        Object.entries(grouped).map(([genre, list]) => (
+          <GenreBlock key={genre} genre={genre} list={list} />
+        ))
       )}
       {genreInfo?.map((g) =>
         g.canRequest && !g.isOpen ? (

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -7,17 +7,34 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
   ref: React.RefObject<T>
 ) {
   useLayoutEffect(() => {
+    const routeKey = location.pathname + location.search;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
-      if (!raw) return;
-      const store = JSON.parse(raw) as Record<string, { x?: Record<string, number> }>;
-      const routeKey = location.pathname + location.search;
-      const left = store[routeKey]?.x?.[key];
-      if (typeof left === "number" && ref.current) {
-        ref.current.scrollLeft = left;
+      if (raw) {
+        const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
+        const left = store[routeKey]?.x?.[key];
+        if (typeof left === "number" && ref.current) {
+          const original = ref.current.style.scrollBehavior;
+          ref.current.style.scrollBehavior = "auto";
+          ref.current.scrollLeft = left;
+          ref.current.style.scrollBehavior = original;
+        }
       }
     } catch {
-      // ignore
+      // ignore read error
     }
+    return () => {
+      try {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        const store = raw ? (JSON.parse(raw) as Record<string, { y: number; x: Record<string, number> }>) : {};
+        const entry = store[routeKey] ?? { y: 0, x: {} };
+        entry.y = window.scrollY;
+        entry.x[key] = ref.current?.scrollLeft ?? 0;
+        store[routeKey] = entry;
+        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+      } catch {
+        // ignore write error
+      }
+    };
   }, [key, ref]);
 }

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -5,7 +5,7 @@ const STORAGE_KEY = "scroll-store";
 
 export default function useHorizontalScrollRestore<T extends HTMLElement>(
   key: string,
-  ref: React.RefObject<T> | null,
+  ref: React.RefObject<T | null>,
 ) {
   const pathname = usePathname();
   const search = useSearchParams();

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -1,4 +1,5 @@
 import { useLayoutEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
 const STORAGE_KEY = "scroll-store";
 
@@ -6,8 +7,11 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
   key: string,
   ref: React.RefObject<T>
 ) {
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const routeKey = pathname + search.toString();
+
   useLayoutEffect(() => {
-    const routeKey = location.pathname + location.search;
     const element = ref.current;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
@@ -38,5 +42,5 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
         // ignore write error
       }
     };
-  }, [key, ref]);
+  }, [key, ref, routeKey]);
 }

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect } from "react";
+
+const STORAGE_KEY = "scroll-store";
+
+export default function useHorizontalScrollRestore<T extends HTMLElement>(
+  key: string,
+  ref: React.RefObject<T>
+) {
+  useLayoutEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const store = JSON.parse(raw) as Record<string, { x?: Record<string, number> }>;
+      const routeKey = location.pathname + location.search;
+      const left = store[routeKey]?.x?.[key];
+      if (typeof left === "number" && ref.current) {
+        ref.current.scrollLeft = left;
+      }
+    } catch {
+      // ignore
+    }
+  }, [key, ref]);
+}

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -8,16 +8,17 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
 ) {
   useLayoutEffect(() => {
     const routeKey = location.pathname + location.search;
+    const element = ref.current;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
-      if (raw) {
+      if (raw && element) {
         const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
         const left = store[routeKey]?.x?.[key];
-        if (typeof left === "number" && ref.current) {
-          const original = ref.current.style.scrollBehavior;
-          ref.current.style.scrollBehavior = "auto";
-          ref.current.scrollLeft = left;
-          ref.current.style.scrollBehavior = original;
+        if (typeof left === "number") {
+          const original = element.style.scrollBehavior;
+          element.style.scrollBehavior = "auto";
+          element.scrollLeft = left;
+          element.style.scrollBehavior = original;
         }
       }
     } catch {
@@ -26,10 +27,11 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
     return () => {
       try {
         const raw = sessionStorage.getItem(STORAGE_KEY);
-        const store = raw ? (JSON.parse(raw) as Record<string, { y: number; x: Record<string, number> }>) : {};
-        const entry = store[routeKey] ?? { y: 0, x: {} };
-        entry.y = window.scrollY;
-        entry.x[key] = ref.current?.scrollLeft ?? 0;
+        const store = raw
+          ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>)
+          : {};
+        const entry = store[routeKey] ?? { y: store[routeKey]?.y ?? 0, x: {} };
+        entry.x = { ...(entry.x ?? {}), [key]: element?.scrollLeft ?? 0 };
         store[routeKey] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -1,22 +1,27 @@
-import { useLayoutEffect } from "react";
+import { useLayoutEffect, useRef } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
 const STORAGE_KEY = "scroll-store";
 
 export default function useHorizontalScrollRestore<T extends HTMLElement>(
   key: string,
-  ref: React.RefObject<T>
+  ref: React.RefObject<T>,
 ) {
   const pathname = usePathname();
   const search = useSearchParams();
   const routeKey = pathname + search.toString();
+  const keyRef = useRef(routeKey);
 
   useLayoutEffect(() => {
+    keyRef.current = routeKey;
     const element = ref.current;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw && element) {
-        const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
+        const store = JSON.parse(raw) as Record<
+          string,
+          { y?: number; x?: Record<string, number> }
+        >;
         const left = store[routeKey]?.x?.[key];
         if (typeof left === "number") {
           const original = element.style.scrollBehavior;
@@ -32,11 +37,18 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
       try {
         const raw = sessionStorage.getItem(STORAGE_KEY);
         const store = raw
-          ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>)
+          ? (JSON.parse(raw) as Record<
+              string,
+              { y?: number; x?: Record<string, number> }
+            >)
           : {};
-        const entry = store[routeKey] ?? { y: store[routeKey]?.y ?? 0, x: {} };
+        const currentKey = keyRef.current;
+        const entry = store[currentKey] ?? {
+          y: store[currentKey]?.y ?? 0,
+          x: {},
+        };
         entry.x = { ...(entry.x ?? {}), [key]: element?.scrollLeft ?? 0 };
-        store[routeKey] = entry;
+        store[currentKey] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {
         // ignore write error

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
 const STORAGE_KEY = "scroll-store";
@@ -10,10 +10,8 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
   const pathname = usePathname();
   const search = useSearchParams();
   const routeKey = pathname + search.toString();
-  const keyRef = useRef(routeKey);
 
   useLayoutEffect(() => {
-    keyRef.current = routeKey;
     const element = ref.current;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
@@ -33,26 +31,5 @@ export default function useHorizontalScrollRestore<T extends HTMLElement>(
     } catch {
       // ignore read error
     }
-    return () => {
-      try {
-        const raw = sessionStorage.getItem(STORAGE_KEY);
-        const store = raw
-          ? (JSON.parse(raw) as Record<
-              string,
-              { y?: number; x?: Record<string, number> }
-            >)
-          : {};
-        const currentKey = keyRef.current;
-        const entry = store[currentKey] ?? {
-          y: store[currentKey]?.y ?? 0,
-          x: {},
-        };
-        entry.x = { ...(entry.x ?? {}), [key]: element?.scrollLeft ?? 0 };
-        store[currentKey] = entry;
-        sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-      } catch {
-        // ignore write error
-      }
-    };
   }, [key, ref, routeKey]);
 }

--- a/lib/hooks/useHorizontalScrollRestore.ts
+++ b/lib/hooks/useHorizontalScrollRestore.ts
@@ -5,14 +5,14 @@ const STORAGE_KEY = "scroll-store";
 
 export default function useHorizontalScrollRestore<T extends HTMLElement>(
   key: string,
-  ref: React.RefObject<T>,
+  ref: React.RefObject<T> | null,
 ) {
   const pathname = usePathname();
   const search = useSearchParams();
   const routeKey = pathname + search.toString();
 
   useLayoutEffect(() => {
-    const element = ref.current;
+    const element = ref?.current;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw && element) {

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -20,9 +20,27 @@ export default function ScrollRestorer() {
           string,
           { y?: number; x?: Record<string, number> }
         >;
-        const y = store[key]?.y;
-        if (typeof y === "number") {
-          window.scrollTo(0, y);
+        const entry = store[key];
+        if (entry) {
+          if (typeof entry.y === "number") {
+            window.scrollTo(0, entry.y);
+          }
+          if (entry.x) {
+            requestAnimationFrame(() => {
+              document
+                .querySelectorAll<HTMLElement>("[data-scroll-key]")
+                .forEach((el) => {
+                  const k = el.dataset.scrollKey!;
+                  const left = entry.x?.[k];
+                  if (typeof left === "number") {
+                    const behavior = el.style.scrollBehavior;
+                    el.style.scrollBehavior = "auto";
+                    el.scrollLeft = left;
+                    el.style.scrollBehavior = behavior;
+                  }
+                });
+            });
+          }
         }
       }
     } catch {
@@ -32,25 +50,38 @@ export default function ScrollRestorer() {
 
   // save scroll position before navigation and restore after
   useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const nav = window.navigation as any;
     if (nav?.addEventListener) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const onNavigate = (event: any) => {
         const fromKey = location.pathname + location.search;
-        try {
-          const raw = sessionStorage.getItem(STORAGE_KEY);
-          const store = raw
-            ? (JSON.parse(raw) as Record<
-                string,
-                { y?: number; x?: Record<string, number> }
-              >)
-            : {};
-          const prev = store[fromKey];
-          const entry = { x: prev?.x ?? {}, y: window.scrollY };
-          store[fromKey] = entry;
-          sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
-        } catch {
-          // ignore save error
-        }
+        const capture = () => {
+          const x: Record<string, number> = {};
+          document
+            .querySelectorAll<HTMLElement>("[data-scroll-key]")
+            .forEach((el) => {
+              const k = el.dataset.scrollKey;
+              if (k) x[k] = el.scrollLeft;
+            });
+          try {
+            const raw = sessionStorage.getItem(STORAGE_KEY);
+            const store = raw
+              ? (JSON.parse(raw) as Record<
+                  string,
+                  { y?: number; x?: Record<string, number> }
+                >)
+              : {};
+            const prev = store[fromKey];
+            const entry = { x: { ...(prev?.x ?? {}), ...x }, y: window.scrollY };
+            store[fromKey] = entry;
+            sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+          } catch {
+            // ignore save error
+          }
+        };
+
+        capture();
 
         const restore = () => {
           try {
@@ -61,9 +92,25 @@ export default function ScrollRestorer() {
                 string,
                 { y?: number; x?: Record<string, number> }
               >;
-              const y = store[toKey]?.y;
-              if (typeof y === "number") {
-                window.scrollTo(0, y);
+              const entry = store[toKey];
+              if (entry) {
+                if (typeof entry.y === "number") {
+                  window.scrollTo(0, entry.y);
+                }
+                if (entry.x) {
+                  document
+                    .querySelectorAll<HTMLElement>("[data-scroll-key]")
+                    .forEach((el) => {
+                      const k = el.dataset.scrollKey!;
+                      const left = entry.x?.[k];
+                      if (typeof left === "number") {
+                        const behavior = el.style.scrollBehavior;
+                        el.style.scrollBehavior = "auto";
+                        el.scrollLeft = left;
+                        el.style.scrollBehavior = behavior;
+                      }
+                    });
+                }
               }
             }
           } catch {
@@ -85,6 +132,13 @@ export default function ScrollRestorer() {
 
     // fallback when Navigation API is unavailable
     return () => {
+      const x: Record<string, number> = {};
+      document
+        .querySelectorAll<HTMLElement>("[data-scroll-key]")
+        .forEach((el) => {
+          const k = el.dataset.scrollKey;
+          if (k) x[k] = el.scrollLeft;
+        });
       try {
         const currentKey = keyRef.current;
         const raw = sessionStorage.getItem(STORAGE_KEY);
@@ -95,7 +149,7 @@ export default function ScrollRestorer() {
             >)
           : {};
         const prev = store[currentKey];
-        const entry = { x: prev?.x ?? {}, y: window.scrollY };
+        const entry = { x: { ...(prev?.x ?? {}), ...x }, y: window.scrollY };
         store[currentKey] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -1,66 +1,54 @@
 "use client";
 import { useEffect } from "react";
 
+const STORAGE_KEY = "scroll-store";
+
 export default function ScrollRestorer() {
   useEffect(() => {
     const nav = window.navigation;
     if (!nav) return; // API 非対応ブラウザ
 
-    const store = new Map<
-      string,
-      { y: number; x: Record<string, number> }
-    >(); // pathname+search → scroll positions
+    const readStore = () => {
+      try {
+        return JSON.parse(sessionStorage.getItem(STORAGE_KEY) || "{}") as Record<
+          string,
+          { y: number; x: Record<string, number> }
+        >;
+      } catch {
+        return {};
+      }
+    };
+
+    const writeStore = (data: Record<string, { y: number; x: Record<string, number> }>) => {
+      sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    };
+
+    let store = readStore();
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const onNavigate = (event: any) => {
       // TODO: 型定義が存在しないため any を利用
       const fromKey = location.pathname + location.search;
       const x: Record<string, number> = {};
-      document
-        .querySelectorAll<HTMLElement>("[data-scroll-key]")
-        .forEach((el) => {
-          const key = el.dataset.scrollKey;
-          if (key) x[key] = el.scrollLeft;
-        });
-      store.set(fromKey, { y: window.scrollY, x });
+      document.querySelectorAll<HTMLElement>("[data-scroll-key]").forEach((el) => {
+        const key = el.dataset.scrollKey;
+        if (key) x[key] = el.scrollLeft;
+      });
+      store[fromKey] = { y: window.scrollY, x };
+      writeStore(store);
 
-      /* ---- View-Transition が無い遷移 ---- */
+      const restoreY = () => {
+        const toKey = location.pathname + location.search;
+        store = readStore();
+        window.scrollTo(0, store[toKey]?.y ?? 0);
+      };
+
       if (!event.transition) {
-        // 1 フレーム後に即復元
-        requestAnimationFrame(() => {
-          const toKey = location.pathname + location.search;
-          const state = store.get(toKey);
-          if (state) {
-            window.scrollTo(0, state.y);
-            Object.entries(state.x).forEach(([key, left]) => {
-              const el = document.querySelector<HTMLElement>(
-                `[data-scroll-key="${key}"]`
-              );
-              if (el) el.scrollLeft = left;
-            });
-          } else {
-            window.scrollTo(0, 0);
-          }
-        });
+        requestAnimationFrame(restoreY);
         return;
       }
 
-      /* ---- View-Transition あり ---- */
-      event.transition.finished.finally(() => {
-        const toKey = location.pathname + location.search;
-        const state = store.get(toKey);
-        const y = state?.y ?? 0;
-        const xMap = state?.x ?? {};
-        requestAnimationFrame(() => {
-          window.scrollTo(0, y);
-          Object.entries(xMap).forEach(([key, left]) => {
-            const el = document.querySelector<HTMLElement>(
-              `[data-scroll-key="${key}"]`
-            );
-            if (el) el.scrollLeft = left;
-          });
-        });
-      });
+      event.transition.finished.finally(() => requestAnimationFrame(restoreY));
     };
 
     nav.addEventListener("navigate", onNavigate);

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -25,14 +25,56 @@ export default function ScrollRestorer() {
     }
   }, [key]);
 
-  // save scroll position when navigating away
+  // save scroll position before navigation and restore after
   useEffect(() => {
+    const nav = window.navigation as any;
+    if (nav?.addEventListener) {
+      const onNavigate = (event: any) => {
+        const fromKey = location.pathname + location.search;
+        try {
+          const raw = sessionStorage.getItem(STORAGE_KEY);
+          const store = raw ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>) : {};
+          const prev = store[fromKey];
+          const entry = { x: prev?.x ?? {}, y: window.scrollY };
+          store[fromKey] = entry;
+          sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+        } catch {
+          // ignore save error
+        }
+
+        const restore = () => {
+          try {
+            const toKey = location.pathname + location.search;
+            const raw = sessionStorage.getItem(STORAGE_KEY);
+            if (raw) {
+              const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
+              const y = store[toKey]?.y;
+              if (typeof y === "number") {
+                window.scrollTo(0, y);
+              }
+            }
+          } catch {
+            // ignore restore errors
+          }
+        };
+
+        if (event.transition) {
+          event.transition.finished.finally(() => requestAnimationFrame(restore));
+        } else {
+          requestAnimationFrame(restore);
+        }
+      };
+      nav.addEventListener("navigate", onNavigate);
+      return () => nav.removeEventListener("navigate", onNavigate);
+    }
+
+    // fallback when Navigation API is unavailable
     return () => {
       try {
         const raw = sessionStorage.getItem(STORAGE_KEY);
         const store = raw ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>) : {};
-        const entry = store[key] ?? { x: {} };
-        entry.y = window.scrollY;
+        const prev = store[key];
+        const entry = { x: prev?.x ?? {}, y: window.scrollY };
         store[key] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -1,12 +1,16 @@
 "use client";
 import { useEffect, useLayoutEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
 
 const STORAGE_KEY = "scroll-store";
 
 export default function ScrollRestorer() {
-  // restore scroll when the app first loads
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const key = pathname + search.toString();
+
+  // restore scroll position for the current route
   useLayoutEffect(() => {
-    const key = location.pathname + location.search;
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw) {
@@ -19,52 +23,23 @@ export default function ScrollRestorer() {
     } catch {
       // ignore restore errors
     }
-  }, []);
+  }, [key]);
 
-  // handle saving/restoring on navigation
+  // save scroll position when navigating away
   useEffect(() => {
-    const nav = window.navigation;
-    if (!nav) return;
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onNavigate = (event: any) => {
-      const fromKey = location.pathname + location.search;
-      // persist scroll position of the page we're leaving
+    return () => {
       try {
         const raw = sessionStorage.getItem(STORAGE_KEY);
         const store = raw ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>) : {};
-        const entry = store[fromKey] ?? { x: {} };
+        const entry = store[key] ?? { x: {} };
         entry.y = window.scrollY;
-        store[fromKey] = entry;
+        store[key] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {
         // ignore save errors
       }
-
-      const restore = () => {
-        const toKey = location.pathname + location.search;
-        try {
-          const raw = sessionStorage.getItem(STORAGE_KEY);
-          if (raw) {
-            const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
-            const y = store[toKey]?.y ?? 0;
-            requestAnimationFrame(() => window.scrollTo(0, y));
-          }
-        } catch {
-          // ignore restore errors
-        }
-      };
-
-      if (event.transition) {
-        event.transition.finished.finally(restore);
-      } else {
-        restore();
-      }
     };
-
-    nav.addEventListener("navigate", onNavigate);
-    return () => nav.removeEventListener("navigate", onNavigate);
-  }, []);
+  }, [key]);
 
   return null;
 }

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -13,7 +13,7 @@ export default function ScrollRestorer() {
     try {
       const raw = sessionStorage.getItem(STORAGE_KEY);
       if (raw) {
-        const store = JSON.parse(raw) as Record<string, { y: number }>;
+        const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
         const y = store[key]?.y;
         if (typeof y === "number") {
           window.scrollTo(0, y);
@@ -25,8 +25,12 @@ export default function ScrollRestorer() {
     return () => {
       try {
         const raw = sessionStorage.getItem(STORAGE_KEY);
-        const store = raw ? (JSON.parse(raw) as Record<string, { y: number }>) : {};
-        store[key] = { y: window.scrollY };
+        const store = raw
+          ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>)
+          : {};
+        const entry = store[key] ?? { x: {} };
+        entry.y = window.scrollY;
+        store[key] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {
         // ignore save errors

--- a/lib/providers/ScrollRestorer.tsx
+++ b/lib/providers/ScrollRestorer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useLayoutEffect } from "react";
 const STORAGE_KEY = "scroll-store";
 
 export default function ScrollRestorer() {
-  // restore vertical scroll on mount
+  // restore scroll when the app first loads
   useLayoutEffect(() => {
     const key = location.pathname + location.search;
     try {
@@ -21,25 +21,44 @@ export default function ScrollRestorer() {
     }
   }, []);
 
-  // store vertical scroll before navigating away
+  // handle saving/restoring on navigation
   useEffect(() => {
     const nav = window.navigation;
     if (!nav) return;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const onNavigate = (_event: any) => {
+    const onNavigate = (event: any) => {
       const fromKey = location.pathname + location.search;
+      // persist scroll position of the page we're leaving
       try {
         const raw = sessionStorage.getItem(STORAGE_KEY);
-        const store = raw
-          ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>)
-          : {};
+        const store = raw ? (JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>) : {};
         const entry = store[fromKey] ?? { x: {} };
         entry.y = window.scrollY;
         store[fromKey] = entry;
         sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
       } catch {
         // ignore save errors
+      }
+
+      const restore = () => {
+        const toKey = location.pathname + location.search;
+        try {
+          const raw = sessionStorage.getItem(STORAGE_KEY);
+          if (raw) {
+            const store = JSON.parse(raw) as Record<string, { y?: number; x?: Record<string, number> }>;
+            const y = store[toKey]?.y ?? 0;
+            requestAnimationFrame(() => window.scrollTo(0, y));
+          }
+        } catch {
+          // ignore restore errors
+        }
+      };
+
+      if (event.transition) {
+        event.transition.finished.finally(restore);
+      } else {
+        restore();
       }
     };
 


### PR DESCRIPTION
## Summary
- preserve horizontal scroll position across navigation
- tag assignment lists with `data-scroll-key` to restore specific lists

## Testing
- `pnpm install` *(fails: Failed to fetch sha256 checksum 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845a9594cc483329e37641c6013d1af